### PR TITLE
Remove utf8_encode call in constants.php

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -45,7 +45,7 @@ define("ABSOLUTE_MAX", 10000000000000);
 /* Replacement to the PHP null keyword */
 define("VOID", 0.123456789);
 /* Euro symbol for GD fonts */
-define("EURO_SYMBOL", utf8_encode("&#8364;"));
+define("EURO_SYMBOL", "&#8364;");
 
 /**
  * pDraw


### PR DESCRIPTION
Creates compatibility for php8.2, which deprecated the utf8_encode function.

As proposed in #19343